### PR TITLE
Use `exec` to directly import solution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v3

--- a/tests/loader_test.py
+++ b/tests/loader_test.py
@@ -1,14 +1,8 @@
-import os
 from yeetcode.loader import load_problem, load_module
-
-# NOTE: These tests create temporary files and remove them later.
-# For `load_problem` a workaround is to pass in raw yaml directly;
-# However, for `load_module`, there seems no way to load python source
-# without calling `exec` (a lot more dangerous than creating tmp files).
 
 
 def test_load_problem():
-    yaml_str = """
+    yaml_raw = """
 Greeting:
   hello:
     name: str
@@ -21,13 +15,7 @@ tests:
   return: "Hello, World!"
 """
 
-    dir = os.path.dirname(os.path.abspath(__file__))
-    tmp_yaml = os.path.join(dir, "tmp.yaml")
-    with open(tmp_yaml, "w") as f:
-        f.write(yaml_str)
-    problem = load_problem(tmp_yaml)
-    os.remove(tmp_yaml)
-
+    problem = load_problem(yaml_raw)
     assert problem.class_name == "Greeting"
     assert problem.methods == {"hello": {"name": "str", "return": "str"}}
     assert problem.test_cases == [
@@ -43,11 +31,6 @@ class Greeting:
         return f"Hello, {name}!"
 """
 
-    dir = os.path.dirname(os.path.abspath(__file__))
-    tmp_py = os.path.join(dir, "tmp.py")
-    with open(tmp_py, "w") as f:
-        f.write(py_str)
-    module = load_module(tmp_py)
+    module = load_module(py_str)
     greeting = module.Greeting()
     assert greeting.hello("World") == "Hello, World!"
-    os.remove(tmp_py)

--- a/yeetcode/__init__.py
+++ b/yeetcode/__init__.py
@@ -1,19 +1,65 @@
-import sys
+import argparse
+import importlib.metadata
 
 from .loader import load_problem, load_module
 
 
+__version__ = importlib.metadata.version(__package__)
+
+
+def print_template(args):
+    problem = load_problem(args.yaml_path.read())
+    src = problem.generate_py()
+    # just print the template to stdout, let user redirect
+    print(src, end="")
+
+
+def run_solution(args):
+    problem = load_problem(args.yaml_path.read())
+    module = load_module(args.py_path.read())
+    problem.run_tests(module)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Make your own leetcode problems"
+    )
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+    )
+    parser.set_defaults(func=lambda _: parser.print_help())
+    subparsers = parser.add_subparsers()
+
+    parser_template = subparsers.add_parser(
+        "template", help="print solution template"
+    )
+    parser_template.add_argument(
+        "yaml_path",
+        type=argparse.FileType(),
+        help="path to problem config",
+    )
+    parser_template.set_defaults(func=print_template)
+
+    parser_run = subparsers.add_parser("run", help="run your solution")
+    parser_run.add_argument(
+        "yaml_path",
+        type=argparse.FileType(),
+        help="path to problem config",
+    )
+    parser_run.add_argument(
+        "py_path",
+        type=argparse.FileType(),
+        help="path to solution",
+    )
+    parser_run.set_defaults(func=run_solution)
+
+    return parser
+
+
 def main():
-    subcommand = sys.argv[1]
-    if subcommand == "template":
-        yaml_path = sys.argv[2]
-        problem = load_problem(yaml_path)
-        src = problem.generate_py()
-        # just print the template to stdout, let user redirect
-        print(src, end="")
-    elif subcommand == "run":
-        yaml_path = sys.argv[2]
-        py_path = sys.argv[3]
-        problem = load_problem(yaml_path)
-        module = load_module(py_path)
-        problem.run_tests(module)
+    parser = build_parser()
+    args = parser.parse_args()
+    args.func(args)

--- a/yeetcode/loader.py
+++ b/yeetcode/loader.py
@@ -1,12 +1,10 @@
-import sys
 import yaml
 import importlib.util
 from .problem import Problem, SingleMethodProblem, MultiMethodProblem
 
 
-def load_problem(yaml_path: str) -> Problem:
-    with open(yaml_path) as f:
-        cfg = yaml.safe_load(f)
+def load_problem(yaml_raw: str) -> Problem:
+    cfg = yaml.safe_load(yaml_raw)
 
     test_cases = cfg.pop("tests", [])
     assert len(cfg) == 1, "too many classes"
@@ -17,11 +15,9 @@ def load_problem(yaml_path: str) -> Problem:
         return MultiMethodProblem(class_name, methods, test_cases)
 
 
-def load_module(py_path: str, module_name: str = "solution"):
-    spec = importlib.util.spec_from_file_location(module_name, py_path)
-    assert spec is not None, "cannot load module"
+def load_module(py_raw: str, module_name: str = "solution"):
+    spec = importlib.util.spec_from_loader(module_name, loader=None)
     module = importlib.util.module_from_spec(spec)
-    sys.modules[module_name] = module
-    assert spec.loader is not None, "cannot get loader"
-    spec.loader.exec_module(module)
+    # exec is dangerous, but it does not run on my computer
+    exec(py_raw, module.__dict__)
     return module

--- a/yeetcode/problem.py
+++ b/yeetcode/problem.py
@@ -49,7 +49,7 @@ class SingleMethodProblem(Problem):
         for kwargs in self.test_cases:
             expect = kwargs.pop("return", None)
             assert test_func(**kwargs) == expect, "test failed"
-        print("Test passed")
+        print("test passed")
 
 
 class MultiMethodProblem(Problem):


### PR DESCRIPTION
This directly uses `exec` to import user solution to module, so it coordinates better with tests and cli. Allegedly `exec` is dangerous, and you should never run it with unverified user input (which is exactly what I'm doing here). But at the end, this runs on users' machine; You have the rights to wipe your whole drive, and I don't care, at least at this moment. Also, cli parsing included.